### PR TITLE
Minor fixes.

### DIFF
--- a/src/Estimation_Simultaneous.jl
+++ b/src/Estimation_Simultaneous.jl
@@ -16,8 +16,7 @@ C, Y = simulate_simultaneous(β, rand(Normal(100, 3), 100), rand(Normal(0, 5), 1
 model = Simultaneous(C, Y, Uniform(0, 1), Normal(100, 3), Normal(0, 5), 1000)
 
 # we start the estimation process from the true values
-θ₀ = inverse(model.transformation, β)
-
+θ₀ = inverse(model.transformation, (β,))
 
 # wrap for gradient calculations
 

--- a/src/Simultaneous.jl
+++ b/src/Simultaneous.jl
@@ -73,8 +73,11 @@ Convenience constructor for ToySimultaneousModel.
 Take in the observed data, the prior, and number of simulations (M).
 """
 function Simultaneous(Cs, Ys, prior_β, dist_x, dist_us, M)
-    transformation = transformation_to(Segment(minimum(prior_β), maximum(prior_β)), LOGISTIC) 
-    Simultaneous(Cs, Ys, rand(dist_x, M), dist_x, prior_β, rand(dist_us, M), dist_us, transformation)
+    βtrans = transformation_to(Segment(minimum(prior_β), maximum(prior_β)),
+                               LOGISTIC)
+    transformation = TransformationTuple((βtrans,))
+    Simultaneous(Cs, Ys, rand(dist_x, M), dist_x, prior_β, rand(dist_us, M),
+                 dist_us, transformation)
 end
 
 
@@ -84,7 +87,7 @@ end
 
 function (pp::Simultaneous)(θ)
     @unpack Cs, Ys, Xs, prior_β, us, transformation = pp
-    β = transformation(θ)
+    β, = transformation(θ)
     logprior = logpdf(prior_β, β)
     Ones = ones(length(us))
     ## Generating the data


### PR DESCRIPTION
Since parameters are always (flat) vectors, it would be best to use a
TransformationTuple even if there is a single parameter.

Note that the code still does not run, lines 97,99 of Simultaneous.jl
have dimension mismatches.

Also, note that the logjac correction is missing.